### PR TITLE
[heft-jest-plugin] Add -c shorthand option to --config

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/dr-dashc_2023-05-19-21-12.json
+++ b/common/changes/@rushstack/heft-jest-plugin/dr-dashc_2023-05-19-21-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Added --test-path-ignore-patterns support for subtractive test selection to complement existing additive support. Added -c short param option to --config to mirror jest support/docs to.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -665,6 +665,7 @@ export class JestPlugin implements IHeftPlugin<IJestPluginOptions> {
     const config: IHeftStringParameter = heftSession.commandLine.registerStringParameter({
       associatedActionNames: ['test'],
       parameterLongName: '--config',
+      parameterShortName: '-c',
       argumentName: 'RELATIVE_PATH',
       description:
         'Use this parameter to control which Jest configuration file will be used to run Jest tests.' +


### PR DESCRIPTION
Adding this trivial -c change as it matches alternate approaches to test group splitting and gives a working opportunity to get the "rush change" to work.